### PR TITLE
Changed postToSugar(urlStr) function to call overloaded version taking content parameter postToSugar(urlStr, content)

### DIFF
--- a/src/main/java/com/sugarcrm/api/v4/impl/SugarApi.java
+++ b/src/main/java/com/sugarcrm/api/v4/impl/SugarApi.java
@@ -535,6 +535,10 @@ public class SugarApi
 
 	public String postToSugar(final String urlStr) throws Exception
 	{
+        // @drmcg - 2016-03-07 - Changed to call overloaded version of postToSugar that takes content parameter as call to SuiteCRM requires content length when sending POST request
+        return postToSugar(urlStr, "");
+        
+        /*
 		final URL url = new URL(urlStr);
 		final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
 		conn.setRequestMethod("POST");
@@ -562,6 +566,7 @@ public class SugarApi
 		conn.disconnect();
 
 		return sb.toString();
+        */
 	}
 
 


### PR DESCRIPTION
Changed Changed postToSugar(urlStr) function to call overloaded version
of postToSugar(urlStr, content) that takes content as call to SuiteCRM
requires content length when sending POST request.

This is due to getting an error that 'Length' (Content-Length) was missing from the POST request when trying to login to SuiteCRM using the application.
